### PR TITLE
fix: resolve integration test failures

### DIFF
--- a/mezon/models.py
+++ b/mezon/models.py
@@ -1200,7 +1200,7 @@ class ChannelMessageRemove(BaseModel):
 class ChannelMessageAck(BaseModel):
     """Channel message acknowledgement"""
 
-    channel_id: int
+    channel_id: Optional[int] = None
     mode: Optional[int] = None
     message_id: Optional[int] = None
     code: Optional[int] = 0

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -189,7 +189,7 @@ class MessageTests(BaseTestSuite):
             clan = await self.client.clans.fetch(self.config.clan_id)
             channel = await clan.channels.fetch(self.config.channel_id)
             await channel.send_ephemeral(
-                receiver_id=self.config.user_id,
+                receiver_ids=[self.config.user_id],
                 content=ChannelMessageContent(t="👻 Ephemeral test message"),
             )
             self.log_result("Ephemeral Message", True)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -22,13 +22,21 @@ Environment Variables:
 import asyncio
 import logging
 import os
-import sys
 import time
 from typing import Optional
 
 from mezon import MezonClient
 
-from tests import BinaryApiTests, BuzzTests, ClanTests, InteractiveTests, MentionTests, MessageTests, SessionTests, UserTests
+from tests import (
+    BinaryApiTests,
+    BuzzTests,
+    ClanTests,
+    InteractiveTests,
+    MentionTests,
+    MessageTests,
+    SessionTests,
+    UserTests,
+)
 from tests.base import TestConfig, TestResults, print_test_summary
 from tests.test_quick_menu import QuickMenuTests
 from tests.test_tokens import TokenTests


### PR DESCRIPTION
- Make ChannelMessageAck.channel_id optional (server omits it in responses)
- Fix send_ephemeral call to use receiver_ids list parameter
- Auto-format test_runner.py imports