### PR TITLE
fix: allow partial user profile update payloads

### DIFF
--- a/mezon/models.py
+++ b/mezon/models.py
@@ -984,10 +984,10 @@ class UserProfileUpdatedEvent(BaseModel):
     """User profile updated event"""
 
     user_id: int
-    display_name: str
-    avatar: str
-    about_me: str
-    channel_id: int
+    display_name: Optional[str] = None
+    avatar: Optional[str] = None
+    about_me: Optional[str] = None
+    channel_id: Optional[int] = None
     clan_id: int
 
 

--- a/tests/test_event_models.py
+++ b/tests/test_event_models.py
@@ -1,0 +1,18 @@
+from mezon.models import UserProfileUpdatedEvent
+
+
+def test_user_profile_updated_event_allows_partial_payload() -> None:
+    event = UserProfileUpdatedEvent.model_validate(
+        {
+            "user_id": "184067432015",
+            "avatar": "https://example.com/avatar.png",
+            "clan_id": "1779484504377790464",
+        }
+    )
+
+    assert event.user_id == 184067432015
+    assert event.display_name is None
+    assert event.avatar == "https://example.com/avatar.png"
+    assert event.about_me is None
+    assert event.channel_id is None
+    assert event.clan_id == 1779484504377790464


### PR DESCRIPTION
## Summary
- relax `UserProfileUpdatedEvent` fields that are missing in real-time payloads
- add a regression test covering partial `user_profile_updated_event` data
- prevent conversion failures that fall back to protobuf objects and emit noisy logs

## Testing
- uv run pytest tests/test_event_models.py